### PR TITLE
Fix case 3 of rb-tree insert fix up diagram

### DIFF
--- a/pictures/fixColorsAfterInsertionCases/case3.tex
+++ b/pictures/fixColorsAfterInsertionCases/case3.tex
@@ -24,7 +24,7 @@
             \end{scope}
         \end{forest}
     \begin{forest}
-        [,shape=coordinate[$B$,rbBlackNodeStyle[$A$,rbRedNodeStyle[,phantom][$D$,rbBlackNodeStyle]][$C$,rbRedNodeStyle]]\toplefttreemark{z}]
+        [,shape=coordinate[$B$,rbBlackNodeStyle[$A$,rbRedNodeStyle][$C$,rbRedNodeStyle[,phantom][$D$,rbBlackNodeStyle]]]\toplefttreemark{z}]
     \end{forest}
 
 \end{document}


### PR DESCRIPTION
Beforehand, the rotate was wrong

Now: 

![image](https://github.com/Rdeisenroth/AuD-Zusammenfassung/assets/41330025/851b272a-91d4-4cd2-801b-243b3ddca07f)
